### PR TITLE
Make splash2x.raytrace GCC-10 compatible

### DIFF
--- a/ext/splash2x/apps/raytrace/src/Makefile
+++ b/ext/splash2x/apps/raytrace/src/Makefile
@@ -1,6 +1,7 @@
 TARGET = raytrace
 OBJS = bbox.o cr.o env.o fbuf.o geo.o huprn.o husetup.o hutv.o isect.o main.o matrix.o memory.o poly.o raystack.o shade.o sph.o trace.o tri.o workpool.o
 
+CFLAGS := $(CFLAGS) -fcommon
 CFLAGS := $(CFLAGS) -Wall -W -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wdisabled-optimization
 CFLAGS := $(CFLAGS) -Wpadded -Winline -Wpointer-arith -Wsign-compare -Wendif-labels
 LDFLAGS := $(LDFLAGS) -lm 


### PR DESCRIPTION
Fix the issue described in #2 - `splash2x.raytrace` requiring the common model, which is not the default anymore from GCC 10 onwards.

I think at least another package has the same problem, but can't remember which one; I'm marking this as Closes #2 nonetheless.

I don't know if `splash2.raytrace` should be fixed as well or not, since from the README, I gather that it's not really clear what's its purpose.